### PR TITLE
URL Cleanup

### DIFF
--- a/tools/NUnit/bin/framework/nunit.framework.xml
+++ b/tools/NUnit/bin/framework/nunit.framework.xml
@@ -3634,7 +3634,7 @@
             <remarks>
               <para>
                 The floating point comparison code is based on this excellent article:
-                http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
+                https://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
               </para>
               <para>
                 "ULP" means Unit in the Last Place and in the context of this library refers to
@@ -3672,7 +3672,7 @@
               </para>
               <para>
                 Implementation partially follows the code outlined here:
-                http://www.anttirt.net/2007/08/19/proper-floating-point-comparisons/
+                https://anttirt.net/2007/08/19/proper-floating-point-comparisons/
               </para>
             </remarks>
         </member>
@@ -3699,7 +3699,7 @@
               </para>
               <para>
                 Implementation partially follows the code outlined here:
-                http://www.anttirt.net/2007/08/19/proper-floating-point-comparisons/
+                https://anttirt.net/2007/08/19/proper-floating-point-comparisons/
               </para>
             </remarks>
         </member>

--- a/tools/NUnit/bin/lib/NSubstitute.xml
+++ b/tools/NUnit/bin/lib/NSubstitute.xml
@@ -135,8 +135,8 @@
             <returns></returns>
             <remarks>
             This implementation was sanity-checked against the 
-            <a href="http://msmvps.com/blogs/jon_skeet/archive/2011/01/14/reimplementing-linq-to-objects-part-35-zip.aspx">Edulinq implementation</a> and
-            <a href="http://blogs.msdn.com/b/ericlippert/archive/2009/05/07/zip-me-up.aspx">Eric Lippert's implementation</a>.
+            <a href="https://msmvps.com/blogs/jon_skeet/archive/2011/01/14/reimplementing-linq-to-objects-part-35-zip.aspx">Edulinq implementation</a> and
+            <a href="https://blogs.msdn.com/b/ericlippert/archive/2009/05/07/zip-me-up.aspx">Eric Lippert's implementation</a>.
             </remarks>
         </member>
         <member name="M:NSubstitute.Core.Extensions.IsCompatibleWith(System.Object,System.Type)">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.anttirt.net/2007/08/19/proper-floating-point-comparisons/ (301) with 2 occurrences migrated to:  
  https://anttirt.net/2007/08/19/proper-floating-point-comparisons/ ([https](https://www.anttirt.net/2007/08/19/proper-floating-point-comparisons/) result SSLHandshakeException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm with 1 occurrences migrated to:  
  https://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm ([https](https://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm) result 200).
* http://blogs.msdn.com/b/ericlippert/archive/2009/05/07/zip-me-up.aspx with 1 occurrences migrated to:  
  https://blogs.msdn.com/b/ericlippert/archive/2009/05/07/zip-me-up.aspx ([https](https://blogs.msdn.com/b/ericlippert/archive/2009/05/07/zip-me-up.aspx) result 301).
* http://msmvps.com/blogs/jon_skeet/archive/2011/01/14/reimplementing-linq-to-objects-part-35-zip.aspx with 1 occurrences migrated to:  
  https://msmvps.com/blogs/jon_skeet/archive/2011/01/14/reimplementing-linq-to-objects-part-35-zip.aspx ([https](https://msmvps.com/blogs/jon_skeet/archive/2011/01/14/reimplementing-linq-to-objects-part-35-zip.aspx) result 301).

# Ignored
These URLs were intentionally ignored.

* http://www.w3.org/2001/XMLSchema with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences