### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use Spring Retry for .NET in your applications, you should use the NuGet Pack
 
 ## Checking out and Building
 
-To check out the project from [GitHub](https://github.com/SpringSource/spring-net-amqp) and build from source using [MSBuild](http://msdn.microsoft.com/en-us/library/vstudio/dd393574.aspx), do the following from a command prompt:
+To check out the project from [GitHub](https://github.com/SpringSource/spring-net-amqp) and build from source using [MSBuild](https://msdn.microsoft.com/en-us/library/vstudio/dd393574.aspx), do the following from a command prompt:
 
     git clone git://github.com/SpringSource/spring-net-retry.git
     cd spring-net-retry


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://schemas.microsoft.com/developer/msbuild/2003 (404) with 4 occurrences could not be migrated:  
   ([https](https://schemas.microsoft.com/developer/msbuild/2003) result AnnotatedConnectException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://msdn.microsoft.com/en-us/library/vstudio/dd393574.aspx with 1 occurrences migrated to:  
  https://msdn.microsoft.com/en-us/library/vstudio/dd393574.aspx ([https](https://msdn.microsoft.com/en-us/library/vstudio/dd393574.aspx) result 301).

# Ignored
These URLs were intentionally ignored.

* http://schemas.microsoft.com/winfx/2006/xaml with 1 occurrences
* http://schemas.microsoft.com/winfx/2006/xaml/presentation with 1 occurrences