### PR TITLE
URL Cleanup

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -71,7 +71,7 @@
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 the License. You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry.Tests/Classify/BackToBackPatternClassifierTests.cs
+++ b/src/Spring.Retry.Tests/Classify/BackToBackPatternClassifierTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry.Tests/Classify/BinaryExceptionClassifierTests.cs
+++ b/src/Spring.Retry.Tests/Classify/BinaryExceptionClassifierTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry.Tests/Classify/ClassifierAdapterTests.cs
+++ b/src/Spring.Retry.Tests/Classify/ClassifierAdapterTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry.Tests/Classify/ClassifierSupportTests.cs
+++ b/src/Spring.Retry.Tests/Classify/ClassifierSupportTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry.Tests/Classify/PatternMatchingClassifierTests.cs
+++ b/src/Spring.Retry.Tests/Classify/PatternMatchingClassifierTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry.Tests/Classify/SubclassExceptionClassifierTests.cs
+++ b/src/Spring.Retry.Tests/Classify/SubclassExceptionClassifierTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry.Tests/Retry/AbstractExceptionTests.cs
+++ b/src/Spring.Retry.Tests/Retry/AbstractExceptionTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry.Tests/Retry/BackOffInterruptedExceptionTests.cs
+++ b/src/Spring.Retry.Tests/Retry/BackOffInterruptedExceptionTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry.Tests/Retry/ExhaustedRetryExceptionTests.cs
+++ b/src/Spring.Retry.Tests/Retry/ExhaustedRetryExceptionTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry.Tests/Retry/ResourcelessTransactionManager.cs
+++ b/src/Spring.Retry.Tests/Retry/ResourcelessTransactionManager.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry.Tests/Retry/RetryExceptionTests.cs
+++ b/src/Spring.Retry.Tests/Retry/RetryExceptionTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry.Tests/Retry/TerminatedRetryExceptionTests.cs
+++ b/src/Spring.Retry.Tests/Retry/TerminatedRetryExceptionTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/Attributes/ClassifierAttribute.cs
+++ b/src/Spring.Retry/Classify/Attributes/ClassifierAttribute.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/BackToBackPatternClassifier.cs
+++ b/src/Spring.Retry/Classify/BackToBackPatternClassifier.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/BinaryExceptionClassifier.cs
+++ b/src/Spring.Retry/Classify/BinaryExceptionClassifier.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/ClassifierAdapter.cs
+++ b/src/Spring.Retry/Classify/ClassifierAdapter.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/ClassifierSupport.cs
+++ b/src/Spring.Retry/Classify/ClassifierSupport.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/IClassifier.cs
+++ b/src/Spring.Retry/Classify/IClassifier.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/PatternMatcher.cs
+++ b/src/Spring.Retry/Classify/PatternMatcher.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/PatternMatchingClassifier.cs
+++ b/src/Spring.Retry/Classify/PatternMatchingClassifier.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/Util/AttributeMethodResolver.cs
+++ b/src/Spring.Retry/Classify/Util/AttributeMethodResolver.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/Util/IMethodInvoker.cs
+++ b/src/Spring.Retry/Classify/Util/IMethodInvoker.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/Util/IMethodResolver.cs
+++ b/src/Spring.Retry/Classify/Util/IMethodResolver.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/Util/MethodInvokerUtils.cs
+++ b/src/Spring.Retry/Classify/Util/MethodInvokerUtils.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Classify/Util/SimpleMethodInvoker.cs
+++ b/src/Spring.Retry/Classify/Util/SimpleMethodInvoker.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Properties/AssemblyInfo.cs
+++ b/src/Spring.Retry/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Backoff/BackOffInterruptedException.cs
+++ b/src/Spring.Retry/Retry/Backoff/BackOffInterruptedException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Backoff/ExponentialBackOffPolicy.cs
+++ b/src/Spring.Retry/Retry/Backoff/ExponentialBackOffPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Backoff/ExponentialRandomBackOffPolicy.cs
+++ b/src/Spring.Retry/Retry/Backoff/ExponentialRandomBackOffPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Backoff/FixedBackOffPolicy.cs
+++ b/src/Spring.Retry/Retry/Backoff/FixedBackOffPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Backoff/IBackOffContext.cs
+++ b/src/Spring.Retry/Retry/Backoff/IBackOffContext.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Backoff/IBackOffPolicy.cs
+++ b/src/Spring.Retry/Retry/Backoff/IBackOffPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Backoff/ISleeper.cs
+++ b/src/Spring.Retry/Retry/Backoff/ISleeper.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Backoff/ISleepingBackOffPolicy.cs
+++ b/src/Spring.Retry/Retry/Backoff/ISleepingBackOffPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Backoff/NoBackOffPolicy.cs
+++ b/src/Spring.Retry/Retry/Backoff/NoBackOffPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Backoff/ObjectWaitSleeper.cs
+++ b/src/Spring.Retry/Retry/Backoff/ObjectWaitSleeper.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Backoff/StatelessBackOffPolicy.cs
+++ b/src/Spring.Retry/Retry/Backoff/StatelessBackOffPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Context/RetryContextSupport.cs
+++ b/src/Spring.Retry/Retry/Context/RetryContextSupport.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/ExhaustedRetryException.cs
+++ b/src/Spring.Retry/Retry/ExhaustedRetryException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/IRecoveryCallback.cs
+++ b/src/Spring.Retry/Retry/IRecoveryCallback.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/IRetryCallback.cs
+++ b/src/Spring.Retry/Retry/IRetryCallback.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/IRetryContext.cs
+++ b/src/Spring.Retry/Retry/IRetryContext.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/IRetryListener.cs
+++ b/src/Spring.Retry/Retry/IRetryListener.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/IRetryOperations.cs
+++ b/src/Spring.Retry/Retry/IRetryOperations.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/IRetryPolicy.cs
+++ b/src/Spring.Retry/Retry/IRetryPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/IRetryState.cs
+++ b/src/Spring.Retry/Retry/IRetryState.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/IRetryStatistics.cs
+++ b/src/Spring.Retry/Retry/IRetryStatistics.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Interceptor/IMethodArgumentsKeyGenerator.cs
+++ b/src/Spring.Retry/Retry/Interceptor/IMethodArgumentsKeyGenerator.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Interceptor/IMethodInvocationRecoverer.cs
+++ b/src/Spring.Retry/Retry/Interceptor/IMethodInvocationRecoverer.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Interceptor/INewMethodArgumentsIdentifier.cs
+++ b/src/Spring.Retry/Retry/Interceptor/INewMethodArgumentsIdentifier.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Interceptor/IProxyMethodInvocation.cs
+++ b/src/Spring.Retry/Retry/Interceptor/IProxyMethodInvocation.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Interceptor/RetryOperationsInterceptor.cs
+++ b/src/Spring.Retry/Retry/Interceptor/RetryOperationsInterceptor.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Interceptor/StatefulRetryOperationsInterceptor.cs
+++ b/src/Spring.Retry/Retry/Interceptor/StatefulRetryOperationsInterceptor.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Listener/RetryListenerSupport.cs
+++ b/src/Spring.Retry/Retry/Listener/RetryListenerSupport.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Policy/AlwaysRetryPolicy.cs
+++ b/src/Spring.Retry/Retry/Policy/AlwaysRetryPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Policy/CompositeRetryPolicy.cs
+++ b/src/Spring.Retry/Retry/Policy/CompositeRetryPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Policy/ExceptionClassifierRetryPolicy.cs
+++ b/src/Spring.Retry/Retry/Policy/ExceptionClassifierRetryPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Policy/IRetryContextCache.cs
+++ b/src/Spring.Retry/Retry/Policy/IRetryContextCache.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Policy/MapRetryContextCache.cs
+++ b/src/Spring.Retry/Retry/Policy/MapRetryContextCache.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Policy/RetryCacheCapacityExceededException.cs
+++ b/src/Spring.Retry/Retry/Policy/RetryCacheCapacityExceededException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Policy/SimpleRetryPolicy.cs
+++ b/src/Spring.Retry/Retry/Policy/SimpleRetryPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Policy/SoftReferenceMapRetryContextCache.cs
+++ b/src/Spring.Retry/Retry/Policy/SoftReferenceMapRetryContextCache.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Policy/TimeoutRetryPolicy.cs
+++ b/src/Spring.Retry/Retry/Policy/TimeoutRetryPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/RetryException.cs
+++ b/src/Spring.Retry/Retry/RetryException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Support/DefaultRetryState.cs
+++ b/src/Spring.Retry/Retry/Support/DefaultRetryState.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Support/NeverRetryPolicy.cs
+++ b/src/Spring.Retry/Retry/Support/NeverRetryPolicy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Support/RetrySimulation.cs
+++ b/src/Spring.Retry/Retry/Support/RetrySimulation.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Support/RetrySimulator.cs
+++ b/src/Spring.Retry/Retry/Support/RetrySimulator.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Support/RetrySynchronizationManager.cs
+++ b/src/Spring.Retry/Retry/Support/RetrySynchronizationManager.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/Support/RetryTemplate.cs
+++ b/src/Spring.Retry/Retry/Support/RetryTemplate.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Retry/TerminatedRetryException.cs
+++ b/src/Spring.Retry/Retry/TerminatedRetryException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Retry/Support/TypeExtensions.cs
+++ b/src/Spring.Retry/Support/TypeExtensions.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 73 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).